### PR TITLE
Handles 409s or instance in conflicting state

### DIFF
--- a/qonos/db/simple/api.py
+++ b/qonos/db/simple/api.py
@@ -442,7 +442,8 @@ def job_get_and_assign_next_by_action(action, worker_id, max_retry,
     job_id = job_ref['id']
     DATA['jobs'][job_id]['worker_id'] = worker_id
     DATA['jobs'][job_id]['timeout'] = new_timeout
-    DATA['jobs'][job_id]['retry_count'] = job_ref['retry_count'] + 1
+    if DATA['jobs'][job_id]['status'] != 'DEFERRED':
+        DATA['jobs'][job_id]['retry_count'] = job_ref['retry_count'] + 1
     job = copy.deepcopy(DATA['jobs'][job_id])
     job['job_metadata'] = job_meta_get_all_by_job_id(job_id)
 

--- a/qonos/db/sqlalchemy/api.py
+++ b/qonos/db/sqlalchemy/api.py
@@ -662,11 +662,14 @@ def job_get_and_assign_next_by_action(action, worker_id, max_retry,
     # Make sure the job has not changed unexpectedly since
     # retrieving it
     try:
+        updated_job_info = {'worker_id': worker_id,
+                            'timeout': new_timeout}
+        if job_ref['status'] != 'DEFERRED':
+            updated_job_info['retry_count'] = job_ref['retry_count'] + 1
+
         query = session.query(models.Job).filter_by(id=job_ref['id'])\
                        .filter_by(updated_at=job_ref['updated_at'])\
-                       .update({'worker_id': worker_id,
-                                'timeout': new_timeout,
-                                'retry_count': job_ref['retry_count'] + 1})
+                       .update(updated_job_info)
     except sa_orm.exc.NoResultFound:
         #In case the job was deleted during assignment return nothing
         return None

--- a/qonos/worker/snapshot/snapshot.py
+++ b/qonos/worker/snapshot/snapshot.py
@@ -209,6 +209,12 @@ class SnapshotProcessor(worker.JobProcessor):
             self._job_cancelled(job_id, msg)
             self._delete_schedule(schedule_id, instance_id)
             return None
+        except exceptions.Conflict:
+            msg = ('Instance %(instance_id)s specified by job %(job_id)s '
+                   'is in conflicting state.' %
+                   {'instance_id': instance_id, 'job_id': job_id})
+            self.update_job(job_id, 'DEFERRED')
+            return None
 
         LOG.info(_("Worker %(worker_id)s Started create image: "
                    " %(image_id)s") % {'worker_id': self.worker.worker_id,


### PR DESCRIPTION
Resolves rm1304 and rm1305

Whenever a 409 is returned, the job status is set to deferred
and retry count is not incremented.