### PR TITLE
Remove timezone from qonos timestamp while creating jobs

### DIFF
--- a/qonos/api/v1/jobs.py
+++ b/qonos/api/v1/jobs.py
@@ -87,13 +87,11 @@ class JobsController(object):
         if expected_next_run:
             try:
                 expected_next_run = timeutils.parse_isotime(expected_next_run)
-                expected_next_run = expected_next_run.replace(tzinfo=None)
             except ValueError as e:
                 msg = _('Invalid "next_run" value. Must be ISO 8601 format')
                 raise webob.exc.HTTPBadRequest(explanation=msg)
 
         next_run = api_utils.schedule_to_next_run(schedule, timeutils.utcnow())
-        next_run = next_run.replace(tzinfo=None)
         try:
             self.db_api.schedule_test_and_set_next_run(schedule['id'],
                         expected_next_run, next_run)

--- a/qonos/common/timeutils.py
+++ b/qonos/common/timeutils.py
@@ -89,7 +89,7 @@ def utcnow():
     """Overridable version of utils.utcnow."""
     if utcnow.override_time_seq:
         return _utcnow_override_time()
-    return datetime.datetime.utcnow().replace(tzinfo=None)
+    return datetime.datetime.utcnow()
 
 
 def _utcnow_override_time():

--- a/qonos/db/simple/api.py
+++ b/qonos/db/simple/api.py
@@ -222,8 +222,7 @@ def schedule_test_and_set_next_run(schedule_id, expected_next_run, next_run):
             current_next_run = current_next_run.replace(tzinfo=None)
         if expected_next_run != current_next_run:
             raise exception.NotFound()
-    if next_run:
-        next_run = next_run.replace(tzinfo=None)
+
     schedule['next_run'] = next_run
 
 

--- a/qonos/db/sqlalchemy/models.py
+++ b/qonos/db/sqlalchemy/models.py
@@ -23,6 +23,7 @@ from sqlalchemy import Column, Integer, String, Index
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy import ForeignKey, DateTime, Text
 from sqlalchemy.orm import relationship, backref, object_mapper
+from sqlalchemy.types import TypeDecorator
 from sqlalchemy import UniqueConstraint
 
 from qonos.common import timeutils
@@ -33,6 +34,19 @@ COMMON_TABLE_ARGS = {
     'mysql_engine': 'InnoDB',
     'mysql_charset': 'utf8'
 }
+
+
+class NoTZDateTime(TypeDecorator):
+    """Represents an DateTime without Time Zone."""
+
+    impl = DateTime
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            return value.replace(tzinfo=None)
+
+    def process_result_value(self, value, dialect):
+        return value
 
 
 class ModelBase(object):
@@ -108,7 +122,7 @@ class Schedule(BASE, ModelBase):
     month = Column(Integer, nullable=True)
     day_of_week = Column(Integer, nullable=True)
     last_scheduled = Column(DateTime, nullable=True)
-    next_run = Column(DateTime, nullable=True, index=True)
+    next_run = Column(NoTZDateTime, nullable=True, index=True)
 
 
 class ScheduleMetadata(BASE, ModelBase):

--- a/qonos/tests/unit/db/test_sqlalchemy.py
+++ b/qonos/tests/unit/db/test_sqlalchemy.py
@@ -14,7 +14,9 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from qonos.common import timeutils
 import qonos.db.sqlalchemy.api as db_api
+import qonos.db.sqlalchemy.models as models
 from qonos.tests import utils as utils
 
 
@@ -53,3 +55,24 @@ class TestSqlalchemySpecificApi(utils.BaseTestCase):
         self.assertTrue(isinstance(value[0], dict))
         self.assertEqual(value[0].get('foo'), 'bar')
         self.assertFalse('_sa_instance_state' in value[1])
+
+
+class TestSqlalchemyTypeDecorator(utils.BaseTestCase):
+
+    def test_no_timezone_datetime_for_db_storing(self):
+        datetime_with_tz = timeutils.parse_isotime('2014-03-14T02:30:00Z')
+
+        self.assertIsNotNone(datetime_with_tz.tzinfo)
+        no_tz_datetime = models.NoTZDateTime()
+        result_datetime = no_tz_datetime.process_bind_param(datetime_with_tz,
+                                                            None)
+        self.assertIsNone(result_datetime.tzinfo)
+
+    def test_no_timezone_datetime_for_db_retrieval(self):
+        datetime_value = timeutils.utcnow()
+
+        self.assertIsNone(datetime_value.tzinfo)
+        no_tz_datetime = models.NoTZDateTime()
+        result_datetime = no_tz_datetime.process_result_value(datetime_value,
+                                                              None)
+        self.assertEqual(datetime_value, result_datetime)

--- a/qonos/tests/unit/v1/test_jobs.py
+++ b/qonos/tests/unit/v1/test_jobs.py
@@ -55,15 +55,13 @@ class TestJobsApi(test_utils.BaseTestCase):
         self.stubs.Set(utils, 'generate_notification', fake_gen_notify)
 
     def _create_jobs(self):
-        next_run = timeutils.parse_isotime('2012-11-27T02:30:00Z').\
-                             replace(tzinfo=None)
         fixture = {
             'id': unit_utils.SCHEDULE_UUID1,
             'tenant': unit_utils.TENANT1,
             'action': 'snapshot',
             'minute': '30',
             'hour': '2',
-            'next_run': next_run,
+            'next_run': timeutils.parse_isotime('2012-11-27T02:30:00Z')
         }
         self.schedule_1 = db_api.schedule_create(fixture)
         fixture = {
@@ -72,7 +70,7 @@ class TestJobsApi(test_utils.BaseTestCase):
             'action': 'snapshot',
             'minute': '30',
             'hour': '2',
-            'next_run': next_run,
+            'next_run': timeutils.parse_isotime('2012-11-27T02:30:00Z'),
             'schedule_metadata': [
                     {
                     'key': 'instance_id',
@@ -303,8 +301,7 @@ class TestJobsApi(test_utils.BaseTestCase):
 
     def test_create(self):
 
-        expected_next_run = timeutils.parse_isotime('1989-01-19T12:00:00Z').\
-                                      replace(tzinfo=None)
+        expected_next_run = timeutils.parse_isotime('1989-01-19T12:00:00Z')
         self._stub_notifications(None, 'qonos.job.create', 'fake-payload',
                                  'INFO')
 
@@ -335,8 +332,7 @@ class TestJobsApi(test_utils.BaseTestCase):
 
     def test_create_with_next_run(self):
 
-        expected_next_run = timeutils.parse_isotime('1989-01-19T12:00:00Z').\
-                                      replace(tzinfo=None)
+        expected_next_run = timeutils.parse_isotime('1989-01-19T12:00:00Z')
 
         def fake_schedule_to_next_run(_schedule, start_time=None):
             self.assertEqual(timeutils.utcnow(), start_time)
@@ -350,7 +346,7 @@ class TestJobsApi(test_utils.BaseTestCase):
         request = unit_utils.get_fake_request(method='POST')
         fixture = {'job': {'schedule_id': self.schedule_1['id'],
                            'next_run':
-                           timeutils.isotime(self.schedule_1['next_run']),}}
+                           timeutils.isotime(self.schedule_1['next_run'])}}
         job = self.controller.create(request, fixture).get('job')
         self.assertNotEqual(job, None)
         self.assertNotEqual(job.get('id'), None)


### PR DESCRIPTION
- Alternative approach for trimming the timezone from datetime

Fixes RM#5316

Co-authored-by: Sridevi Koushik <sridevi.koushik@rackspace.com>