### PR TITLE
Have worker backoff more aggressively on failure

### DIFF
--- a/qonos/qonosclient/client.py
+++ b/qonos/qonosclient/client.py
@@ -65,6 +65,9 @@ class Client(object):
         if response.status == 409:
             raise exception.Duplicate('Resource Exists')
 
+        if response.status == 429:
+            raise exception.TooManyRequests('Too Many Requests')
+
         if method != 'DELETE':
             body = response.read()
             if body != '':

--- a/qonos/qonosclient/exception.py
+++ b/qonos/qonosclient/exception.py
@@ -29,3 +29,7 @@ class Duplicate(Exception):
 
 class BadRequest(Exception):
     pass
+
+
+class TooManyRequests(Exception):
+    pass


### PR DESCRIPTION
The worker right now does not perform any type of
additional backoff when a failure comes in.  In
those cases we backoff by the maximum allowed.

This change also includes having the worker backoff
based on previous recorded Rest calls.

RM9088