### PR TITLE
Upgrade SQLAlchemy version requirements

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -3,7 +3,7 @@
 # package to get the right headers...
 greenlet>=0.3.1
 
-SQLAlchemy>=0.7.8,<0.7.99
+SQLAlchemy>=0.8
 anyjson
 eventlet>=0.9.12
 kombu>=1.0.4
@@ -15,7 +15,7 @@ argparse
 iso8601>=0.1.8
 croniter
 oslo.config
-sqlalchemy-migrate>=0.7.2
+sqlalchemy-migrate>=0.9.2
 
 #Client only reqs
 docopt==0.6.1


### PR DESCRIPTION
Updated to SQLAlchemy >= 0.8 and sqlalchemy-migrate >= 0.9.2.

Current sqlalchemy-migrate is 0.9.2 and requires at least SQLAlchemy 0.8. Hence the chosen versions here.

