### PR TITLE
Remove SQLAchemy pinning

### DIFF
--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -3,7 +3,7 @@
 # package to get the right headers...
 greenlet>=0.3.1
 
-SQLAlchemy>=0.7.8,<0.7.99
+SQLAlchemy
 anyjson
 eventlet>=0.9.12
 kombu>=1.0.4


### PR DESCRIPTION
This resolves a conflict between nova's requirements
for a 9.X verison and qonos requirements for a 7.X version.
The original reason qonos pinned to 7.X was because nova
operated on 7.X which is no longer the case.