### PR TITLE
Moving hard timeout and retry notifications back to api.

### DIFF
--- a/etc/qonos/qonos-api.conf.sample
+++ b/etc/qonos/qonos-api.conf.sample
@@ -34,12 +34,16 @@ action_overrides = snapshot
 
 # Default settings for actions if not otherwise specified below
 [action_default]
+# The number of times a job may be reassigned when it is detected
+# that a worker has stopped working on it.
+max_retry = 3
 # The total amount of time that a job will be worked on (including
 # retries) before it is considered failed completely.
 timeout_seconds = 3600
 
 # Settings for the 'snapshot' action
 [action_snapshot]
+max_retry = 2
 timeout_seconds = 14400
 
 [paste_deploy]

--- a/etc/qonos/qonos-worker.conf.sample
+++ b/etc/qonos/qonos-worker.conf.sample
@@ -37,10 +37,6 @@ job_timeout_max_updates = 3
 # in seconds
 job_timeout_worker_stop_sec = 300
 
-# The number of times a job may be reassigned when it is detected
-# that a worker has stopped working on it.
-max_retry = 5
-
 [nova_client_factory]
 # Common options for either Nova client factory
 auth_protocol = 'http'

--- a/qonos/api/api.py
+++ b/qonos/api/api.py
@@ -37,6 +37,7 @@ api_opts = [
 
 action_opts = [
     cfg.IntOpt('timeout_seconds', default=60),
+    cfg.IntOpt('max_retry', default=5),
 ]
 
 CONF = cfg.CONF

--- a/qonos/api/v1/api_utils.py
+++ b/qonos/api/v1/api_utils.py
@@ -104,3 +104,10 @@ def get_new_timeout_by_action(action):
         group = 'action_default'
     job_timeout_seconds = CONF.get(group).timeout_seconds
     return now + datetime.timedelta(seconds=job_timeout_seconds)
+
+
+def job_get_max_retry(action):
+    group = 'action_' + action
+    if group not in CONF:
+        group = 'action_default'
+    return CONF.get(group).max_retry

--- a/qonos/api/v1/workers.py
+++ b/qonos/api/v1/workers.py
@@ -13,12 +13,13 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
+import copy
 import webob.exc
 
 from qonos.api import api
 from qonos.api.v1 import api_utils
 from qonos.common import exception
+from qonos.common import timeutils
 from qonos.common import utils
 import qonos.db
 from qonos.openstack.common._i18n import _
@@ -84,12 +85,54 @@ class WorkersController(object):
 
         new_timeout = api_utils.get_new_timeout_by_action(action)
 
-        job = self.db_api.job_get_and_assign_next_by_action(
-            action, worker_id, new_timeout)
-        if job:
+        while True:
+            job = self.db_api.job_get_and_assign_next_by_action(
+                action, worker_id, new_timeout)
+            if job is None:
+                break
+
             utils.serialize_datetimes(job)
             api_utils.serialize_job_metadata(job)
+
+            if self.validate_job(job):
+                break
+
         return {'job': job}
+
+    def validate_job(self, job_payload):
+        job = copy.deepcopy(job_payload)
+        max_retry = api_utils.job_get_max_retry(job['action'])
+        if job['retry_count'] >= max_retry:
+            self._notify_job_failed_status(job, 'MAX_RETRIED')
+            return False
+
+        now = timeutils.utcnow()
+        hard_timeout = timeutils.normalize_time(
+            timeutils.parse_isotime(job['hard_timeout']))
+        if hard_timeout <= now:
+            self._notify_job_failed_status(job, 'HARD_TIMED_OUT')
+            return False
+
+        return True
+
+    def _update_job_status(self, job_id, status):
+        values = {'status': status.upper()}
+
+        try:
+            return self.db_api.job_update(job_id, values)
+        except exception.NotFound:
+            msg = (_('Job %s could not be found while updating status to %s.')
+                   % (job_id, status))
+            raise webob.exc.HTTPNotFound(explanation=msg)
+
+    def _notify_job_failed_status(self, job, status):
+        job = self._update_job_status(job['id'], status)
+        job['error_message'] = ''
+        job = {'job': job}
+        utils.generate_notification(None,
+                                    'qonos.job.failed',
+                                    job,
+                                    'ERROR')
 
 
 def create_resource():

--- a/qonos/tests/functional/worker/test_snapshot_processor.py
+++ b/qonos/tests/functional/worker/test_snapshot_processor.py
@@ -134,10 +134,10 @@ class BaseTestSnapshotProcessor(utils.BaseTestCase):
         server.retention = retention
         return server
 
-    def job_fixture(self, instance_id, **kwargs):
+    def job_fixture(self, instance_id):
         now = timeutils.utcnow()
-        timeout = timeutils.strtime(now + datetime.timedelta(hours=1))
-        hard_timeout = timeutils.strtime(now + datetime.timedelta(hours=4))
+        timeout = now + datetime.timedelta(hours=1)
+        hard_timeout = now + datetime.timedelta(hours=4)
 
         fixture = {
             'id': 'JOB_1',
@@ -154,8 +154,6 @@ class BaseTestSnapshotProcessor(utils.BaseTestCase):
                 'value': 'my_instance',
             },
         }
-        if kwargs:
-            fixture.update(kwargs)
         return fixture
 
     def image_fixture(self, image_id, status, instance_id, metadata_dict=None):
@@ -340,73 +338,6 @@ class TestSnapshotProcessorJobProcessing(BaseTestSnapshotProcessor):
             #     processor.job['schedule_id'])
             # self.assertEqual('CANCELLED', job['status'])
             self.assert_update_job_statuses(processor, ['PROCESSING', 'ERROR'])
-
-    def test_process_job_should_cancel_if_job_hard_timed_out(self):
-        server = self.server_instance_fixture("INSTANCE_ID", "test")
-
-        now = timeutils.utcnow()
-        expired_hard_timeout = now - datetime.timedelta(hours=4)
-        job = self.job_fixture(server.id,
-                               hard_timeout=timeutils.strtime(
-                                   expired_hard_timeout))
-
-        with TestableSnapshotProcessor(job, server, []) as processor:
-            processor.process_job(job)
-
-            self.assert_update_job_statuses(processor, ['HARD_TIMED_OUT'])
-            self.assertEqual('HARD_TIMED_OUT', job['status'])
-
-            error_msg = ('Job %(job_id)s has reached/exceeded its'
-                         ' hard timeout: %(hard_timeout)s.' %
-                         {'job_id': job['id'],
-                          'hard_timeout': job['hard_timeout']})
-            expected_status_values = {
-                'status': 'HARD_TIMED_OUT',
-                'error_message': error_msg
-            }
-            self.assert_job_status_values(processor, expected_status_values)
-
-    def test_process_job_should_cancel_if_job_is_max_retried(self):
-        server = self.server_instance_fixture("INSTANCE_ID", "test")
-        fake_imageid = "IMAGE_ID"
-        max_retry_count = 1
-        self.config(max_retry=max_retry_count, group='snapshot_worker')
-        self.image_fixture(fake_imageid, 'QUEUED', server.id)
-
-        fake_metadata = dict(image_id=fake_imageid,
-                             instance_id=server.id)
-        job = self.job_fixture(server.id,
-                               retry_count=max_retry_count,
-                               metadata=fake_metadata)
-
-        with TestableSnapshotProcessor(job, server, []) as processor:
-            fake_schedule = {'day_of_week': 'SUNDAY'}
-
-            processor._get_schedule = mock.Mock(
-                return_value=fake_schedule)
-
-            processor._get_image_id = mock.Mock(
-                return_value=fake_imageid)
-
-            processor._poll_image_status = mock.Mock(
-                return_value="ERROR")
-
-            job['retry_count'] += 1
-
-            processor.process_job(job)
-
-            self.assert_update_job_statuses(processor, ['MAX_RETRIED'])
-            self.assertEqual('MAX_RETRIED', job['status'])
-
-            error_msg = ('Job %(job_id)s has reached/exceeded its'
-                         ' max_retry count: %(retry_count)s.' %
-                         {'job_id': job['id'],
-                          'retry_count': job['retry_count']})
-            expected_status_values = {
-                'status': 'MAX_RETRIED',
-                'error_message': error_msg
-            }
-            self.assert_job_status_values(processor, expected_status_values)
 
     def test_process_job_should_cancel_if_schedule_not_exist(self):
         server = self.server_instance_fixture("INSTANCE_ID", "test")
@@ -887,59 +818,6 @@ class TestSnapshotProcessorNotifications(BaseTestSnapshotProcessor):
                 ('qonos.job.retry', 'INFO', 'PROCESSING'),
                 ('qonos.job.update', 'INFO', 'PROCESSING'),
                 ('qonos.job.run.end', 'INFO', 'DONE')]
-            self.assert_job_notification_events(processor,
-                                                expected_notifications)
-
-    def test_notifications_for_cancelled_job_on_hard_timeout_reached(self):
-        server = self.server_instance_fixture("INSTANCE_ID", "test")
-        now = timeutils.utcnow()
-        expired_hard_timeout = now - datetime.timedelta(hours=4)
-        job = self.job_fixture(server.id,
-                               hard_timeout=timeutils.strtime(
-                                   expired_hard_timeout))
-
-        with TestableSnapshotProcessor(job, server, []) as processor:
-            processor.process_job(job)
-
-            self.assertEqual('HARD_TIMED_OUT', job['status'])
-            expected_notifications = [
-                ('qonos.job.run.start', 'INFO', 'QUEUED'),
-                ('qonos.job.failed', 'ERROR', 'HARD_TIMED_OUT')]
-            self.assert_job_notification_events(processor,
-                                                expected_notifications)
-
-    def test_notifications_for_cancelled_job_on_max_retry_count_reached(self):
-        server = self.server_instance_fixture("INSTANCE_ID", "test")
-        fake_imageid = "IMAGE_ID"
-        max_retry_count = 0
-        self.config(max_retry=max_retry_count, group='snapshot_worker')
-        self.image_fixture(fake_imageid, 'QUEUED', server.id)
-        fake_metadata = dict(image_id=fake_imageid,
-                             instance_id=server.id)
-        job = self.job_fixture(server.id,
-                               status='PROCESSING',
-                               retry_count=max_retry_count,
-                               metadata=fake_metadata)
-
-        with TestableSnapshotProcessor(job, server, []) as processor:
-            fake_schedule = {'day_of_week': 'SUNDAY'}
-
-            processor._get_schedule = mock.Mock(
-                return_value=fake_schedule)
-
-            processor._get_image_id = mock.Mock(
-                return_value=fake_imageid)
-
-            processor._poll_image_status = mock.Mock(
-                return_value="ERROR")
-
-            job['retry_count'] += 1
-            processor.process_job(job)
-
-            self.assertEqual('MAX_RETRIED', job['status'])
-            expected_notifications = [
-                ('qonos.job.retry', 'INFO', 'PROCESSING'),
-                ('qonos.job.failed', 'ERROR', 'MAX_RETRIED')]
             self.assert_job_notification_events(processor,
                                                 expected_notifications)
 

--- a/qonos/tests/unit/v1/test_workers.py
+++ b/qonos/tests/unit/v1/test_workers.py
@@ -262,7 +262,6 @@ class TestWorkersApi(test_utils.BaseTestCase):
         self.assertEqual(host, actual['host'])
 
     def test_delete(self):
-        request = unit_utils.get_fake_request(method='GET')
         request = unit_utils.get_fake_request(method='DELETE')
         self.controller.delete(request, self.worker_1['id'])
         self.assertRaises(exception.NotFound, db_api.worker_get_by_id,
@@ -289,6 +288,7 @@ class TestWorkersApi(test_utils.BaseTestCase):
         self.assertEqual(job['job'], None)
 
     def test_get_next_job_for_action(self):
+        self.config(group='action_default', max_retry=5)
         request = unit_utils.get_fake_request(method='POST')
         fixture = {'action': 'snapshot'}
         job = self.controller.get_next_job(request,

--- a/qonos/tests/unit/worker/snapshot/test_snapshot.py
+++ b/qonos/tests/unit/worker/snapshot/test_snapshot.py
@@ -58,7 +58,6 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
         self.snapshot_meta = {
             "org.openstack__1__created_by": "scheduled_images_service"
             }
-        timeutils.clear_time_override()
 
     def tearDown(self):
         self.mox.UnsetStubs()
@@ -137,88 +136,6 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
                              'tenant': '44444444-4444-4444-4444-44444444',
                              'metadata': {'instance_id':
                                           '55555555-5555-5555-5555-55555555'}}}
-        utils.generate_notification(None, 'qonos.job.failed', expected_payload,
-                                    mox.IsA(str))
-        self.mox.ReplayAll()
-
-        processor = TestableSnapshotProcessor(self.nova_client)
-        processor.init_processor(self.worker)
-
-        processor.process_job(self.job)
-
-        self.mox.VerifyAll()
-
-    def test_process_job_should_fail_if_hard_timed_out(self):
-        mox.Reset(self.worker)
-        self.mox.StubOutWithMock(utils, 'generate_notification')
-        now = timeutils.utcnow()
-        self.job['hard_timeout'] = timeutils.strtime(at=now)
-
-        utils.generate_notification(None, 'qonos.job.run.start', mox.IsA(dict),
-                                    mox.IsA(str))
-        self.worker.update_job(fakes.JOB_ID,
-                               'HARD_TIMED_OUT',
-                               timeout=None,
-                               error_message=mox.IsA(str))\
-            .AndReturn({'status': 'HARD_TIMED_OUT',
-                        'timeout': self.job['timeout']})
-        expected_payload = {'job':
-                            {'status': 'HARD_TIMED_OUT',
-                             'hard_timeout': self.job['hard_timeout'],
-                             'created_at': self.job['created_at'],
-                             'modified_at': self.job['modified_at'],
-                             'retry_count': 1,
-                             'schedule_id': '33333333-3333-3333-3333-33333333',
-                             'worker_id': '11111111-1111-1111-1111-11111111',
-                             'timeout': self.job['timeout'],
-                             'action': 'snapshot',
-                             'id': '22222222-2222-2222-2222-22222222',
-                             'tenant': '44444444-4444-4444-4444-44444444',
-                             'metadata': {'instance_id':
-                                          '55555555-5555-5555-5555-55555555'}}}
-
-        utils.generate_notification(None, 'qonos.job.failed', expected_payload,
-                                    mox.IsA(str))
-        self.mox.ReplayAll()
-
-        processor = TestableSnapshotProcessor(self.nova_client)
-        processor.init_processor(self.worker)
-
-        processor.process_job(self.job)
-
-        self.mox.VerifyAll()
-
-    def test_process_job_should_fail_if_it_reached_max_retry_count(self):
-        mox.Reset(self.worker)
-        self.mox.StubOutWithMock(utils, 'generate_notification')
-
-        max_retry_count = 2
-        self.config(max_retry=max_retry_count, group='snapshot_worker')
-        self.job['retry_count'] = max_retry_count + 1
-
-        utils.generate_notification(None, 'qonos.job.run.start', mox.IsA(dict),
-                                    mox.IsA(str))
-        self.worker.update_job(fakes.JOB_ID,
-                               'MAX_RETRIED',
-                               timeout=None,
-                               error_message=mox.IsA(str))\
-            .AndReturn({'status': 'MAX_RETRIED',
-                        'timeout': self.job['timeout']})
-        expected_payload = {'job':
-                            {'status': 'MAX_RETRIED',
-                             'hard_timeout': self.job['hard_timeout'],
-                             'created_at': self.job['created_at'],
-                             'modified_at': self.job['modified_at'],
-                             'retry_count': self.job['retry_count'],
-                             'schedule_id': '33333333-3333-3333-3333-33333333',
-                             'worker_id': '11111111-1111-1111-1111-11111111',
-                             'timeout': self.job['timeout'],
-                             'action': 'snapshot',
-                             'id': '22222222-2222-2222-2222-22222222',
-                             'tenant': '44444444-4444-4444-4444-44444444',
-                             'metadata': {'instance_id':
-                                          '55555555-5555-5555-5555-55555555'}}}
-
         utils.generate_notification(None, 'qonos.job.failed', expected_payload,
                                     mox.IsA(str))
         self.mox.ReplayAll()
@@ -499,7 +416,6 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
         time_seq = [
             base_time,
             base_time,
-            base_time,
             base_time + datetime.timedelta(seconds=305),
             base_time + datetime.timedelta(seconds=605),
             base_time + datetime.timedelta(seconds=905),
@@ -543,7 +459,6 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
         self.mox.VerifyAll()
 
     def test_process_job_should_update_status_and_timestamp(self):
-        timeutils.set_time_override()
         base_time = timeutils.utcnow()
         time_seq = [
             base_time,
@@ -600,7 +515,6 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
         time_seq = [
             base_time,
             base_time,
-            base_time,
             base_time + datetime.timedelta(minutes=5, seconds=5),
             base_time + datetime.timedelta(minutes=60, seconds=5),
             base_time + datetime.timedelta(minutes=120, seconds=5),
@@ -653,7 +567,6 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
                                                        job=None):
         base_time = timeutils.utcnow()
         time_seq = [
-            base_time,
             base_time,
             base_time,
             base_time + datetime.timedelta(seconds=305),
@@ -749,7 +662,7 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
 
         self.mox.VerifyAll()
 
-    def test_process_job_should_exponentially_increase_timeout(self):
+    def test_process_job_should_exponentially_increates_timeout(self):
         status = MockImageStatus('ERROR')
         job = copy.deepcopy(self.job)
         self._do_test_process_job_should_update_image_error(status, job=job)
@@ -759,11 +672,9 @@ class TestSnapshotProcessor(test_utils.BaseTestCase):
         timeutils.set_time_override(new_now)
         job['status'] = 'ERROR'
         job['retry_count'] = 2
-        job['hard_timeout'] = timeutils.strtime(
-            at=(new_now + datetime.timedelta(minutes=120)))
         self._do_test_process_job_should_update_image_error(
-            status, include_create=False, include_queued=False, is_retry=True,
-            job=job)
+            status, include_create=False, include_queued=False,
+            is_retry=True, job=job)
 
     def test_process_job_should_update_image_error(self):
         status = MockImageStatus('ERROR')

--- a/qonos/worker/snapshot/snapshot.py
+++ b/qonos/worker/snapshot/snapshot.py
@@ -61,8 +61,6 @@ snapshot_worker_opts = [
     cfg.IntOpt('job_timeout_worker_stop_sec', default=300,
                help=_('How far in the future to timeout the job when the '
                       'worker shuts down, in seconds')),
-    cfg.IntOpt('max_retry', default=5,
-               help=_('Maximum number of tries that a job can be processed')),
 ]
 
 CONF = cfg.CONF
@@ -82,7 +80,6 @@ class SnapshotProcessor(worker.JobProcessor):
     def init_processor(self, worker, nova_client_factory=None):
         super(SnapshotProcessor, self).init_processor(worker)
         self.current_job = None
-        self.max_retry = CONF.snapshot_worker.max_retry
         self.timeout_count = 0
         self.timeout_max_updates = CONF.snapshot_worker.job_timeout_max_updates
         self.next_timeout = None
@@ -138,28 +135,6 @@ class SnapshotProcessor(worker.JobProcessor):
 
         job_id = job['id']
 
-        hard_timeout = timeutils.normalize_time(
-            timeutils.parse_isotime(job['hard_timeout']))
-        hard_timed_out = hard_timeout <= self._get_utcnow()
-        if hard_timed_out:
-            msg = ('Job %(job_id)s has reached/exceeded its'
-                   ' hard timeout: %(hard_timeout)s.' %
-                   {'job_id': job_id, 'hard_timeout': job['hard_timeout']})
-            self._job_hard_timed_out(job, msg)
-            LOG.info(_('[%(worker_tag)s] Job hard timed out: %(msg)s') %
-                     {'worker_tag': self.get_worker_tag(), 'msg': msg})
-            return
-
-        max_retried = job['retry_count'] > self.max_retry
-        if max_retried:
-            msg = ('Job %(job_id)s has reached/exceeded its'
-                   ' max_retry count: %(retry_count)s.' %
-                   {'job_id': job_id, 'retry_count': job['retry_count']})
-            self._job_max_retried(job, msg)
-            LOG.info(_('[%(worker_tag)s] Job max_retry reached: %(msg)s') %
-                     {'worker_tag': self.get_worker_tag(), 'msg': msg})
-            return
-
         schedule = self._get_schedule(job)
         if schedule is None:
             msg = ('Schedule %(schedule_id)s not found for job %(job_id)s' %
@@ -207,8 +182,7 @@ class SnapshotProcessor(worker.JobProcessor):
                     self._update_job(job_id, "PROCESSING")
                 except exc.OutOfTimeException:
                     retry = False
-                else:
-                    time.sleep(self.image_poll_interval)
+                time.sleep(self.image_poll_interval)
 
         if active:
             self._process_retention(instance_id,
@@ -493,20 +467,6 @@ class SnapshotProcessor(worker.JobProcessor):
 
     def _job_cancelled(self, job, message):
         response = self.update_job(job['id'], 'CANCELLED',
-                                   error_message=message)
-        if response:
-            self._update_job_with_response(job, response)
-        self.send_notification_job_failed({'job': job})
-
-    def _job_hard_timed_out(self, job, message):
-        response = self.update_job(job['id'], 'HARD_TIMED_OUT',
-                                   error_message=message)
-        if response:
-            self._update_job_with_response(job, response)
-        self.send_notification_job_failed({'job': job})
-
-    def _job_max_retried(self, job, message):
-        response = self.update_job(job['id'], 'MAX_RETRIED',
                                    error_message=message)
         if response:
             self._update_job_with_response(job, response)


### PR DESCRIPTION
The hard timeout and retry concepts are meant to protect the api
from never-finishing jobs continually being retried. When this
was moved to the snapshot processor it put the responsibility
for this protection into the hands of the very thing which could
be causing the problem. It was done thinking that only the workers
should be sending notifications, but since these are really API
concepts enforcement and notification should fall to the API.
Therefore moving these checks back.