### PR TITLE
Remove unneeded comments in openstack-common.conf

### DIFF
--- a/openstack-common.conf
+++ b/openstack-common.conf
@@ -11,32 +11,5 @@ module=sslutils
 module=threadgroup
 module=uuidutils
 
-# The following are no longer part of olso-incubator
-# Keeping here for reference until the process of replacing them is complete
-#modules=cfg - DONE
-#module=utils - DONE (Unused)
-#module=iniparser - DONE (Unused)
-#module=gettextutils - DONE
-#module=pastedeploy - DONE (Unused)
-#module=extensions - DONE (Doesn't appear to have been imported anyway)
-#module=version - DONE (Replaced with pbr.version)
-
-#module=notifier
-#  module=rpc
-#    module=excutils
-#    module=network_utils
-#  module=timeutils
-
-#module=setup
-#module=importutils - Deprecated, replace with stevedore
-
-# Openstack projects are encouraged to use a 3rd party lib like Pecan
-# Modules listed after wsgi are dependencies of wsgi
-#module=wsgi
-#  module=exception
-#  module=jsonutils
-#    module=timeutils
-#  module=xmlutils
-
 # The base module to hold the copy of openstack.common
 base=qonos


### PR DESCRIPTION
Leftover comments were unneeded and clutter the file