### PR TITLE
Pin PEP8 version to 1.5.7

### DIFF
--- a/tools/test-requires
+++ b/tools/test-requires
@@ -6,6 +6,7 @@ Babel
 
 # Needed for testing
 coverage>=3.6
+pep8==1.5.7
 mock
 mox
 nose


### PR DESCRIPTION
Pinning this to stop complaints about:
E402 module level import not at top of file
E731 do not assign a lambda expression, use a def

Will fix properly when time permits